### PR TITLE
Replaced == with = in clusterdock_ssh() for wider shell compatibility.

### DIFF
--- a/clusterdock.sh
+++ b/clusterdock.sh
@@ -139,7 +139,7 @@ clusterdock_ssh() {
 
   local ID
   for ID in $(docker ps -qa); do
-    if [ "$(docker inspect --format '{{.Config.Hostname}}' ${ID})" == "${NODE}" ]; then
+    if [ "$(docker inspect --format '{{.Config.Hostname}}' ${ID})" = "${NODE}" ]; then
       break
     fi
   done


### PR DESCRIPTION
Using zsh, and running clusterdock_ssh() kept throwing a “= not found” message. Looking around, seemed like just a single = was the POSIX standard for string comparison and had wider shell compatibility. Tested the single = in bash and it still worked.